### PR TITLE
feat(api): Extend "Set Manual Control" requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,11 +376,13 @@ You may also find [tado-openapispec-v2](https://github.com/kritsel/tado-openapis
 }
 ```
 
-**Output**:
-```json
-{
-  "status": "success"
-}
+**Possible values**:
+- `power`: `ON`, `OFF`
+- `type`: `TIMER`, `NEXT_TIME_BLOCK`, `MANUAL`
+
+**Response code**:
+```
+204
 ```
 
 ### Set Open Window

--- a/TadoX API Collection.postman_collection.json
+++ b/TadoX API Collection.postman_collection.json
@@ -8,6 +8,282 @@
 	},
 	"item": [
 		{
+			"name": "Set Manual Control",
+			"item": [
+				{
+					"name": "ON",
+					"item": [
+						{
+							"name": "Timer",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"setting\": {\n        \"power\": \"ON\",\n        \"isBoost\": false,\n        \"temperature\": {\n            \"value\": 22.0\n        }\n    },\n    \"termination\": {\n        \"type\": \"TIMER\",\n        \"durationInSeconds\": 600\n    }\n}"
+								},
+								"url": {
+									"raw": "https://hops.tado.com/homes/{{homeId}}/rooms/{{roomId}}/manualControl?ngsw-bypass=true",
+									"protocol": "https",
+									"host": [
+										"hops",
+										"tado",
+										"com"
+									],
+									"path": [
+										"homes",
+										"{{homeId}}",
+										"rooms",
+										"{{roomId}}",
+										"manualControl"
+									],
+									"query": [
+										{
+											"key": "ngsw-bypass",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Next time block",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"setting\": {\n        \"power\": \"ON\",\n        \"isBoost\": false,\n        \"temperature\": {\n            \"value\": 22.0\n        }\n    },\n    \"termination\": {\n        \"type\": \"NEXT_TIME_BLOCK\"\n    }\n}"
+								},
+								"url": {
+									"raw": "https://hops.tado.com/homes/{{homeId}}/rooms/{{roomId}}/manualControl?ngsw-bypass=true",
+									"protocol": "https",
+									"host": [
+										"hops",
+										"tado",
+										"com"
+									],
+									"path": [
+										"homes",
+										"{{homeId}}",
+										"rooms",
+										"{{roomId}}",
+										"manualControl"
+									],
+									"query": [
+										{
+											"key": "ngsw-bypass",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Manual",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"setting\": {\n        \"power\": \"ON\",\n        \"isBoost\": false,\n        \"temperature\": {\n            \"value\": 22.0\n        }\n    },\n    \"termination\": {\n        \"type\": \"MANUAL\"\n    }\n}"
+								},
+								"url": {
+									"raw": "https://hops.tado.com/homes/{{homeId}}/rooms/{{roomId}}/manualControl?ngsw-bypass=true",
+									"protocol": "https",
+									"host": [
+										"hops",
+										"tado",
+										"com"
+									],
+									"path": [
+										"homes",
+										"{{homeId}}",
+										"rooms",
+										"{{roomId}}",
+										"manualControl"
+									],
+									"query": [
+										{
+											"key": "ngsw-bypass",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"description": "Turn on manual control"
+				},
+				{
+					"name": "OFF",
+					"item": [
+						{
+							"name": "Timer",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"setting\": {\n        \"power\": \"OFF\",\n        \"isBoost\": false,\n        \"temperature\": null\n    },\n    \"termination\": {\n        \"type\": \"TIMER\",\n        \"durationInSeconds\": 600\n    }\n}"
+								},
+								"url": {
+									"raw": "https://hops.tado.com/homes/{{homeId}}/rooms/{{roomId}}/manualControl?ngsw-bypass=true",
+									"protocol": "https",
+									"host": [
+										"hops",
+										"tado",
+										"com"
+									],
+									"path": [
+										"homes",
+										"{{homeId}}",
+										"rooms",
+										"{{roomId}}",
+										"manualControl"
+									],
+									"query": [
+										{
+											"key": "ngsw-bypass",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Next time block",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"setting\": {\n        \"power\": \"OFF\",\n        \"isBoost\": false,\n        \"temperature\": null\n    },\n    \"termination\": {\n        \"type\": \"NEXT_TIME_BLOCK\"\n    }\n}"
+								},
+								"url": {
+									"raw": "https://hops.tado.com/homes/{{homeId}}/rooms/{{roomId}}/manualControl?ngsw-bypass=true",
+									"protocol": "https",
+									"host": [
+										"hops",
+										"tado",
+										"com"
+									],
+									"path": [
+										"homes",
+										"{{homeId}}",
+										"rooms",
+										"{{roomId}}",
+										"manualControl"
+									],
+									"query": [
+										{
+											"key": "ngsw-bypass",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Manual",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"setting\": {\n        \"power\": \"OFF\",\n        \"isBoost\": false,\n        \"temperature\": null\n    },\n    \"termination\": {\n        \"type\": \"MANUAL\"\n    }\n}"
+								},
+								"url": {
+									"raw": "https://hops.tado.com/homes/{{homeId}}/rooms/{{roomId}}/manualControl?ngsw-bypass=true",
+									"protocol": "https",
+									"host": [
+										"hops",
+										"tado",
+										"com"
+									],
+									"path": [
+										"homes",
+										"{{homeId}}",
+										"rooms",
+										"{{roomId}}",
+										"manualControl"
+									],
+									"query": [
+										{
+											"key": "ngsw-bypass",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"description": "Turn off manual control"
+				}
+			],
+			"description": "Sets manual control for a specific room."
+		},
+		{
 			"name": "Login",
 			"event": [
 				{
@@ -265,49 +541,6 @@
 						"homes",
 						"{{homeId}}",
 						"roomsAndDevices"
-					],
-					"query": [
-						{
-							"key": "ngsw-bypass",
-							"value": "true"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Set Manual Control",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Authorization",
-						"value": "Bearer {{access_token}}"
-					},
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"setting\":{\"power\":\"OFF\",\"isBoost\":false,\"temperature\":null},\"termination\":{\"type\":\"TIMER\",\"durationInSeconds\":600}}"
-				},
-				"url": {
-					"raw": "https://hops.tado.com/homes/{{homeId}}/rooms/{{roomId}}/manualControl?ngsw-bypass=true",
-					"protocol": "https",
-					"host": [
-						"hops",
-						"tado",
-						"com"
-					],
-					"path": [
-						"homes",
-						"{{homeId}}",
-						"rooms",
-						"{{roomId}}",
-						"manualControl"
 					],
 					"query": [
 						{


### PR DESCRIPTION
Extend the `Set Manual Control` requests to cover additional use cases, specifically:
- turn manual control `ON` or `OFF`
- set the termination type to `TIMER`, `MANUAL` or `NEXT_TIME_BLOCK`

The new requests have been organized into folders, to keep a clean project structure.

Additionally, the documentation has been updated to list the possible values of `power` and `type` properties in the body of the `/manualControl` endpoint.